### PR TITLE
[OPS] Add a workflow to deploy shared-lib when a release PR is merged

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,29 @@
+name: Deploy to Nexus
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache Maven packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Deploy
+        shell: bash
+        run: mvn deploy -s ./settings.xml


### PR DESCRIPTION
## Description

- Add a workflow to deploy shared-lib to private repository when a a release PR is merged

## Checklist

- [x] I have performed a self-review of my own code
- [x] This PR does not introduce a breaking change
- [ ] Unit tests are added/updated (if applicable)
- [x] No error nor warning in the console

