### PR TITLE
[OPS] Update deploy workflow to only deploy when the release PR is merged

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   deploy:
+    if: "${{ github.event.pull_request.merged == true}}"
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
## Description

Update deploy workflow to only deploy when the releas PR is merged

## Checklist

- [x] I have performed a self-review of my own code
- [x] This PR does not introduce a breaking change
- [ ] Unit tests are added/updated (if applicable)
- [x] No error nor warning in the console

