### PR TITLE
[OPS] Update deploy workflow to support legacy maven

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Deploy
         shell: bash
-        run: mvn deploy -s ./settings.xml
+        run: mvn deploy -s ./settings.xml -Dmaven.metadata.legacy=true
         env:
           NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}


### PR DESCRIPTION
## Description

- Add `-Dmaven.metadata.legacy=true` to deploy workflow to support legacy maven

## Checklist

- [x] I have performed a self-review of my own code
- [x] This PR does not introduce a breaking change
- [ ] Unit tests are added/updated (if applicable)
- [x] No error nor warning in the console

