### PR TITLE
[OPS] Remove SNAPSHOT suffix for all modules and depencies

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.ow.shared</groupId>
         <artifactId>shared-lib</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>common</artifactId>

--- a/error-utils/pom.xml
+++ b/error-utils/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.ow.shared</groupId>
         <artifactId>shared-lib</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/jacoco-aggregator/pom.xml
+++ b/jacoco-aggregator/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.ow.shared</groupId>
         <artifactId>shared-lib</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>jacoco-aggregator</artifactId>

--- a/json-utils/pom.xml
+++ b/json-utils/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.ow.shared</groupId>
         <artifactId>shared-lib</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>json-utils</artifactId>

--- a/log-utils/pom.xml
+++ b/log-utils/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.ow.shared</groupId>
         <artifactId>shared-lib</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>log-utils</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <groupId>net.ow.shared</groupId>
   <artifactId>shared-lib</artifactId>
   <name>Shared Lib</name>
-  <version>0.2.0-SNAPSHOT</version>
+  <version>0.2.0</version>
   <packaging>pom</packaging>
 
   <modules>
@@ -75,10 +75,10 @@
     <jacoco.minimum-rate>0.80</jacoco.minimum-rate>
 
     <!-- Modules -->
-    <error-utils.version>0.2.0-SNAPSHOT</error-utils.version>
-    <common.version>0.2.0-SNAPSHOT</common.version>
-    <json-utils.version>0.2.0-SNAPSHOT</json-utils.version>
-    <log-utils.version>0.2.0-SNAPSHOT</log-utils.version>
+    <error-utils.version>0.2.0</error-utils.version>
+    <common.version>0.2.0</common.version>
+    <json-utils.version>0.2.0</json-utils.version>
+    <log-utils.version>0.2.0</log-utils.version>
   </properties>
 
   <distributionManagement>


### PR DESCRIPTION
## Description

- Remove SNAPSHOT suffix for all modules and depencies

Note: This is commit cherry pick from release branch

## Checklist

- [x] I have performed a self-review of my own code
- [x] This PR does not introduce a breaking change
- [ ] Unit tests are added/updated (if applicable)
- [x] No error nor warning in the console