### PR TITLE
[RFT] Refactor HeaderBasedTraceIdProvider's no args constructor from public to private

### DIFF
--- a/log-utils/src/main/java/net/ow/shared/commonlog/provider/trace/HeaderBasedTraceIdProvider.java
+++ b/log-utils/src/main/java/net/ow/shared/commonlog/provider/trace/HeaderBasedTraceIdProvider.java
@@ -2,6 +2,7 @@ package net.ow.shared.commonlog.provider.trace;
 
 import io.micrometer.common.lang.NonNullApi;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -10,8 +11,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Setter
 @NonNullApi
-@NoArgsConstructor
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class HeaderBasedTraceIdProvider implements TraceIdProvider {
     public static final TraceIdProvider DEFAULT_FALLBACK_PROVIDER = new DefaultTraceIdProvider();
 


### PR DESCRIPTION
## Description

- efactor HeaderBasedTraceIdProvider's no args constructor from public to private

## Checklist

- [x] I have performed a self-review of my own code
- [x] This PR does not introduce a breaking change
- [ ] Unit tests are added/updated (if applicable)
- [x] No error nor warning in the console

