### PR TITLE
[FIX] Hanlde null input of DateInstantDeserializer

### DIFF
--- a/json-utils/src/main/java/net/ow/shared/jsonutils/deserializer/DateInstantDeserializer.java
+++ b/json-utils/src/main/java/net/ow/shared/jsonutils/deserializer/DateInstantDeserializer.java
@@ -13,7 +13,11 @@ public class DateInstantDeserializer extends JsonDeserializer<Instant> {
     @Override
     public Instant deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
             throws IOException, DateTimeParseException {
-        LocalDate date = LocalDate.parse(jsonParser.getText());
-        return date.atStartOfDay(ZoneOffset.UTC).toInstant();
+        String text = jsonParser.getText();
+        if (null == text || text.isBlank()) {
+            return null;
+        }
+
+        return LocalDate.parse(text).atStartOfDay(ZoneOffset.UTC).toInstant();
     }
 }

--- a/json-utils/src/test/java/net/ow/shared/jsonutils/deserializer/DateInstantDeserializerTest.java
+++ b/json-utils/src/test/java/net/ow/shared/jsonutils/deserializer/DateInstantDeserializerTest.java
@@ -1,7 +1,6 @@
 package net.ow.shared.jsonutils.deserializer;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.JsonParser;
@@ -45,6 +44,22 @@ class DateInstantDeserializerTest {
         Instant expectResult = SIMPLE_DATE_FORMAT.parse(date).toInstant();
 
         assertEquals(expectResult, actualResult);
+    }
+
+    @Test
+    @SneakyThrows
+    void deserializeTest_whenNullText_thenReturnsNull() {
+        when(jsonParser.getText()).thenReturn(null);
+
+        assertNull(dateInstantDeserializer.deserialize(jsonParser, deserializationContext));
+    }
+
+    @Test
+    @SneakyThrows
+    void deserializeTest_whenBlankText_thenReturnsNull() {
+        when(jsonParser.getText()).thenReturn("   ");
+
+        assertNull(dateInstantDeserializer.deserialize(jsonParser, deserializationContext));
     }
 
     @Test


### PR DESCRIPTION
## Description

- Hanlde null input of DateInstantDeserializer.  Instead of throwing excetpion, it will return null

## Checklist

- [x] I have performed a self-review of my own code
- [x] This PR does not introduce a breaking change
- [ ] Unit tests are added/updated (if applicable)
- [x] No error nor warning in the console

