### PR TITLE
[FIX] Fixed JWTClientInformationProvider to return empty string when no JWT is provided

### DIFF
--- a/log-utils/src/main/java/net/ow/shared/commonlog/provider/client/information/JWTClientInformationProvider.java
+++ b/log-utils/src/main/java/net/ow/shared/commonlog/provider/client/information/JWTClientInformationProvider.java
@@ -32,7 +32,12 @@ public class JWTClientInformationProvider implements ClientInformationProvider {
 
         JWTClaimsSet claims;
         try {
-            String jwt = request.getHeader(HttpHeaders.AUTHORIZATION).replace(BEARER, "");
+            String jwt = request.getHeader(HttpHeaders.AUTHORIZATION);
+            if (null == jwt || jwt.isBlank()) {
+                return Strings.EMPTY;
+            }
+            jwt = jwt.replace(BEARER, "");
+
             claims = JWTUtils.getClaimsSet(jwt);
         } catch (ParseException e) {
             log.error("Fail to parse JWT with error  - {}", e.getMessage());

--- a/log-utils/src/test/java/net/ow/shared/commonlog/provider/client/information/JWTClientInformationProviderTest.java
+++ b/log-utils/src/test/java/net/ow/shared/commonlog/provider/client/information/JWTClientInformationProviderTest.java
@@ -111,4 +111,14 @@ class JWTClientInformationProviderTest {
 
         assertEquals("", result);
     }
+
+    @Test
+    void getClientInformationTest_whenAuthorizationHeaderEmpty_thenReturnsEmptyString() {
+        jwtClientInformationProvider.setClaimKeys(Collections.singleton("sub"));
+        when(httpServletRequest.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn("");
+
+        String result = jwtClientInformationProvider.getClientInformation(httpServletRequest);
+
+        assertEquals("", result);
+    }
 }


### PR DESCRIPTION
## Description

- Fixed JWTClientInformationProvider to return empty string when no JWT is provided

## Checklist

- [x] I have performed a self-review of my own code
- [x] This PR does not introduce a breaking change
- [x] Unit tests are added/updated (if applicable)
- [x] No error nor warning in the console

